### PR TITLE
BLUEXPDOC-95: Clarify Trident upgrade

### DIFF
--- a/concept-kubernetes.adoc
+++ b/concept-kubernetes.adoc
@@ -39,7 +39,7 @@ One of the four most recent versions of Astra Trident link:https://docs.netapp.c
 
 NOTE: Astra Trident deployed using `tridentctl` is not supported. If you deployed Astra Trident using `tridentctl`, you cannot use BlueXP to manage your Kubernetes clusters. You must link:https://docs.netapp.com/us-en/trident/trident-managing-k8s/uninstall-trident.html#uninstall-by-using-tridentctl[uninstall using `tridentctl`^] and reinstall link:https://docs.netapp.com/us-en/trident/trident-get-started/kubernetes-deploy-operator.html[using the Trident operator^] or link:./task/task-k8s-manage-trident.html[using BlueXP]. 
 
-You can install or upgrade to the latest version of Astra Trident directly from BlueXP. 
+You can install Astra Trident or upgrade to a supported version directly from BlueXP. 
 
 link:https://docs.netapp.com/us-en/trident/trident-get-started/requirements.html[Review Astra Trident prerequisites^]
 


### PR DESCRIPTION
You can upgrade only to the latest supported version. You cannot upgrade to the latest version.